### PR TITLE
v1.4.0 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.4" %}
+{% set version = "1.4.0" %}
 
 package:
   name: cis
@@ -7,11 +7,10 @@ package:
 source:
   fn: cis-{{ version }}.tar.gz
   url: https://github.com/cedadev/cis/archive/{{ version }}.tar.gz
-  sha256: 319f404d9af40baf2f1a2f26c43dd82abee906d1450d9d3db8c48df5a2041ff9
+  sha256: f5b79973e459f4347b9726d4310d35ab7e3992361d525a1819371026af2045bb
 
 build:
   number: 0
-  skip: True  # [py3k or osx]
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
Updating version string and sha256. Also removing skip as we now support Python 3 and hopefully OS X build is working!